### PR TITLE
Popravek na Macos -> dodal še .DS_Store kot izjema

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,7 +179,7 @@ def read_input_file(name):
 def load_input_files():
     files = get_files("input/")
     for file in files:
-        if file == '.gitkeep':
+        if file == '.gitkeep' or file == '.DS_Store':
             continue
         read_input_file(file)
 


### PR DESCRIPTION
Ker se na mekih zna zgoditi, da se avtomatsko zgenerira še .DS_Store file, je to potrebno dodati kot izjemo. Nevem točno zakaj ni dovoljen samo .csv file (ali pa filter nekaj različnih) ampak ok.